### PR TITLE
Refactor options.xml to other.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Now if you will start PhpStorm, it will think that it was just installed and sta
 
 Disadvantage of this method is losing all your preferences: your hot keys, appearance, editor settings, last projects, opened files, etc. This utility is backing up your config folder, cleans PhpStorm's Java user preferences containing evaluation period info. Then after you start PhpStorm and select new evaluation period it will merge new config with old one. So you'll be able to continue working from the place where you stopped.
 
-Actually, when merging configs we need to copy all files except `eval/*` and `options/options.xml` from backup to actual config directory. The `options/options.xml` file need to be merged more intellectually line by line with adding `<property>` XML nodes from backed up `options/options.xml` except `evlsprt*` properties.
+Actually, when merging configs we need to copy all files except `eval/*` and `other/other.xml` from backup to actual config directory. The `other/other.xml` file need to be merged more intellectually line by line with adding `<property>` XML nodes from backed up `other/other.xml` except `evlsprt*` properties.
 
 This utility automates this process and doing all these things for you.
 
@@ -63,7 +63,7 @@ Now start PhpStorm and do the following things:
  - Exit PhpStorm
 
 Did it? (y/n) [no] y
-Merging old options/options.xml with new one ... OK
+Merging old other/other.xml with new one ... OK
 Copying all other config files back from backup ... OK
 
 All is done. Now you can start PhpStorm and continue to use it yet another 30 days! :)

--- a/app/PhpstormResetTrial.php
+++ b/app/PhpstormResetTrial.php
@@ -83,7 +83,7 @@ class PhpstormResetTrial
      */
     private function checkIsValidConfigDir()
     {
-        if (!file_exists($this->configDir . '/options/options.xml')) {
+        if (!file_exists($this->configDir . '/options/other.xml')) {
             throw new \Exception("Directory {$this->configDir} is not looks like valid PhpStorm config directory\n");
         }
     }

--- a/app/Steps/Step03.php
+++ b/app/Steps/Step03.php
@@ -25,7 +25,7 @@ class Step03 extends StepAbstract
             " - Exit PhpStorm\n\n";
             do {
                 if (Console::confirm('Did it?')) {
-                    if (file_exists($this->stepConfig->getSettingsConfigDir() . '/options/options.xml')) {
+                    if (file_exists($this->stepConfig->getSettingsConfigDir() . '/options/other.xml')) {
                         break;
                     } else {
                         echo "No, you didn't.\n";
@@ -38,12 +38,12 @@ class Step03 extends StepAbstract
             } while (true);
 
             //
-            // Merging old options/options.xml with new one
+            // Merging old options/other.xml with new one
             //
 
-            echo 'Merging old options/options.xml with new one ... ';
+            echo 'Merging old options/other.xml with new one ... ';
             try {
-                self::mergeOptionsXml($this->stepConfig->getBackupConfigDir() . '/options/options.xml', $this->stepConfig->getSettingsConfigDir() . '/options/options.xml');
+                self::mergeOptionsXml($this->stepConfig->getBackupConfigDir() . '/options/other.xml', $this->stepConfig->getSettingsConfigDir() . '/options/other.xml');
                 echo "OK\n";
             } catch (\RuntimeException $e) {
                 echo "FAILED\n";
@@ -57,7 +57,7 @@ class Step03 extends StepAbstract
             echo 'Copying all other config files back from backup ... ';
             try {
                 File::copyDir($this->stepConfig->getBackupConfigDir(), $this->stepConfig->getSettingsDir(), false, function(\SplFileInfo $entry) {
-                    return $entry->getRealPath() !== realpath($this->stepConfig->getBackupConfigDir() . '/options/options.xml')
+                    return $entry->getRealPath() !== realpath($this->stepConfig->getBackupConfigDir() . '/options/other.xml')
                         && strtolower($entry->getExtension()) !== 'bak'
                         && realpath($entry->getPath()) !== realpath($this->stepConfig->getBackupConfigDir() . '/eval');
                 });
@@ -95,7 +95,7 @@ class Step03 extends StepAbstract
     }
 
     /**
-     * Merges new config/options/options.xml file with old one in backup
+     * Merges new config/options/other.xml file with old one in backup
      *
      * @param string $oldOptionsFile
      * @param string $newOptionsFile


### PR DESCRIPTION
- Node PropertiesComponent has moved to other.xml with options.xml being removed completely in the PHPStorm 2018.3.3 onwards